### PR TITLE
failure explicit interface + increase Notebook abstraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "guru.data-fellas"
 
 name := "spark-notebook-core"
 
-version := "0.1.3-SNAPSHOT"
+version := "0.2.0-SNAPSHOT"
 
 bintrayRepository := "spark-notebook"
 

--- a/src/main/scala/notebook/Notebook.scala
+++ b/src/main/scala/notebook/Notebook.scala
@@ -1,0 +1,55 @@
+package notebook
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import notebook.NBSerializer._
+
+trait Notebook {
+  def metadata: Option[Metadata] = None
+  def cells: Option[List[Cell]] = Some(Nil)
+  def worksheets: Option[List[Worksheet]] = None
+  def autosaved: Option[List[Worksheet]] = None
+  def nbformat: Option[Int]
+  def name: String = metadata.map(_.name).getOrElse("Anonymous")
+  def rawContent: Option[String] = None
+  def isFromRaw = rawContent.isDefined
+}
+
+
+object Notebook {
+
+  private[notebook] case class NotebookImpl( override val metadata: Option[Metadata] = None,
+                           override val cells: Option[List[Cell]] = Some(Nil),
+                           override val worksheets: Option[List[Worksheet]] = None,
+                           override val autosaved: Option[List[Worksheet]] = None,
+                           override val nbformat: Option[Int],
+                           override val rawContent: Option[String]
+                         ) extends Notebook
+
+  def apply(metadata: Option[Metadata] = None,
+            cells: Option[List[Cell]] = Some(Nil),
+            worksheets: Option[List[Worksheet]] = None,
+            autosaved: Option[List[Worksheet]] = None,
+            nbformat: Option[Int],
+            rawContent: Option[String]
+  ): Notebook = {
+      NotebookImpl(metadata, cells, worksheets, autosaved, nbformat, rawContent)
+  }
+
+  def read(str: String)(implicit ex : ExecutionContext): Future[Notebook] = {
+    NBSerializer.fromJson(str).map(nb =>  NotebookImpl(nb.metadata, nb.cells, nb.worksheets, nb.autosaved, nb.nbformat, Some(str)))
+  }
+
+  def write(nb: Notebook)(implicit ex : ExecutionContext): Future[String] = {
+    Future(nb.rawContent).flatMap {
+      case Some(content) => Future.successful(content)
+      case None =>
+        val snb = SerNotebook(nb.metadata, nb.cells, nb.worksheets, nb.autosaved, nb.nbformat)
+        NBSerializer.toJson(snb)
+    }
+  }
+}
+
+class NotebookSerializationException(msg: String) extends Exception(msg)
+class EmptyNotebookException extends Exception ()
+class NotebookNotFoundException(location:String) extends Exception(s"Notebook not found at $location")

--- a/src/main/scala/notebook/Notebook.scala
+++ b/src/main/scala/notebook/Notebook.scala
@@ -50,6 +50,6 @@ object Notebook {
   }
 }
 
-class NotebookSerializationException(msg: String) extends Exception(msg)
+class NotebookDeserializationException(msg: String, cause: Throwable) extends Exception(msg, cause)
 class EmptyNotebookException extends Exception ()
 class NotebookNotFoundException(location:String) extends Exception(s"Notebook not found at $location")

--- a/src/main/scala/notebook/Resource.scala
+++ b/src/main/scala/notebook/Resource.scala
@@ -1,0 +1,10 @@
+package notebook
+
+sealed trait Resource {
+  def name:String
+  def path:String
+}
+
+case class GenericFile(name:String, path:String, tpe:String) extends Resource
+case class Repository(name:String, path:String) extends Resource
+case class NotebookResource(name:String, path:String) extends Resource

--- a/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -39,14 +39,9 @@ class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvid
     }
 
     override def save(path: Path, notebook: Notebook)(implicit ev: ExecutionContext): Future[Notebook] = {
-      Notebook.write(notebook).flatMap { nb =>
-        Try {
+      Notebook.write(notebook).map { nb =>
           Files.write(path, nb.getBytes(StandardCharsets.UTF_8))
-        } match {
-          case Success(_) => Future.successful(notebook)
-          case Failure(ex) => Future.failed(ex)
-        }
-      }
+      }.map(_ => notebook)
     }
   }
 }

--- a/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -4,47 +4,49 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
 import com.typesafe.config.Config
-import notebook.NBSerializer
-import notebook.NBSerializer.Notebook
+import notebook.{Notebook, NotebookNotFoundException}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvider] {
 
 
   override def apply(config: Config): NotebookProvider = new ConfigurableFileSystemNotebook(config)
 
-  private[FileSystemNotebookProviderConfigurator] class ConfigurableFileSystemNotebook(val config:Config) extends NotebookProvider {
+  private[FileSystemNotebookProviderConfigurator] class ConfigurableFileSystemNotebook(val config: Config) extends NotebookProvider {
 
     override lazy val root = Paths.get(config.getString("notebooks.dir"))
 
-    override def delete(path: Path)(implicit ec: ExecutionContext) : Future[Option[Notebook]] = {
-      get(path).map   {
-        case Some(notebook) =>
+    override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = {
+      get(path).flatMap { notebook =>
+        val res: Future[Unit] = try {
           val deleted = Files.deleteIfExists(path)
-          Some(notebook)
-        case x => x
+          if (!deleted) {
+            Future.failed(new NotebookNotFoundException(path.toString))
+          } else {
+            Future.successful(())
+          }
+        } catch {
+          case ex: Throwable => Future.failed(ex)
+        }
+        res.map(_ => notebook)
       }
     }
 
-    override def get(path: Path)(implicit ec: ExecutionContext): Future[Option[Notebook]] = {
-      Future {
-        if (Files.exists(path)) {
-          NBSerializer.read(new String(Files.readAllBytes(path), StandardCharsets.UTF_8))
-        } else {
-          None
+    override def get(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = {
+      Future{Files.readAllBytes(path)}.flatMap(bytes => Notebook.read(new String(bytes, StandardCharsets.UTF_8)))
+    }
+
+    override def save(path: Path, notebook: Notebook)(implicit ev: ExecutionContext): Future[Notebook] = {
+      Notebook.write(notebook).flatMap { nb =>
+        Try {
+          Files.write(path, nb.getBytes(StandardCharsets.UTF_8))
+        } match {
+          case Success(_) => Future.successful(notebook)
+          case Failure(ex) => Future.failed(ex)
         }
       }
-    }
-
-    def save(path: Path, notebook: Notebook)(implicit ec: ExecutionContext): Future[Option[Notebook]] = {
-      Try {
-        Files.write(path, NBSerializer.write(notebook).getBytes(StandardCharsets.UTF_8))
-        get(path)
-      }.getOrElse(Future {
-        Some(notebook)
-      })
     }
   }
 }

--- a/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/src/main/scala/notebook/io/NotebookProvider.scala
@@ -1,12 +1,16 @@
 package notebook.io
 
-import java.nio.file.{Files, Path, Paths}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{DirectoryNotEmptyException, Files, Path, Paths}
+import java.io.{File, FileFilter, IOException}
 
 import com.typesafe.config.{Config, ConfigFactory}
+import notebook._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-import notebook.NBSerializer._
+import scala.util.{Failure, Success, Try}
 
 trait Configurable[T] {
   def apply(config: Config = ConfigFactory.empty()) : T
@@ -14,38 +18,46 @@ trait Configurable[T] {
 
 trait NotebookProvider {
 
-  def verifyProvider(): Future[Unit] = Future {}
+  def verifyProvider(): Future[Unit] = Future.successful(())
+
   def root: Path
-  def delete(path: Path)(implicit ev:ExecutionContext) : Future[Option[Notebook]]
-  def get(path: Path)(implicit ev:ExecutionContext) : Future[Option[Notebook]]
-  def save(path: Path, notebook: Notebook)(implicit ev:ExecutionContext) :  Future[Option[Notebook]]
-  def list(path: Path)(implicit ev:ExecutionContext) : Future[List[Resource]] = {
+
+  def listingPolicy: File => Boolean = NotebookProvider.DefaultListingPolicy
+
+  def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook]
+
+  def get(path: Path)(implicit ev: ExecutionContext): Future[Notebook]
+
+  def save(path: Path, notebook: Notebook)(implicit ev: ExecutionContext): Future[Notebook]
+
+  def list(path: Path)(implicit ev: ExecutionContext): Future[List[Resource]] = {
     val lengthToRoot = root.toFile.getAbsolutePath.length
     def dropRoot(f: java.io.File) = f.getAbsolutePath.drop(lengthToRoot).dropWhile(_ == '/')
 
     Future {
-      val ps:List[java.io.File] = Option(root.resolve(path).toFile.listFiles)
-                                          .filter(_.length != 0) //toList fails if listFils is empty
-                                          .map(_.toList)
-                                          .getOrElse(Nil)
+      val ps: List[java.io.File] = Option(root.resolve(path).toFile.listFiles)
+        .filter(_.length != 0) //toList fails if listFils is empty
+        .map(_.toList)
+        .getOrElse(Nil)
       ps.map { f =>
         val n = f.getName
         if (f.isFile && n.endsWith(".snb")) {
-          NotebookResource(
-            n.dropRight(".snb".length), dropRoot(f)
-          )
+          NotebookResource(n.dropRight(".snb".length), dropRoot(f))
         } else if (f.isFile) {
-          GenericFile(
-            n, dropRoot(f), "file"
-          )
+          GenericFile(n, dropRoot(f), "file")
         } else {
-          Repository(
-            n, dropRoot(f)
-          )
+          Repository(n, dropRoot(f))
         }
       }
     }
   }
 
+}
+
+
+object NotebookProvider {
+  val isNotebookFile: File => Boolean = f => f.isFile && f.getName.endsWith(".snb")
+  val isVisibleDirectory: File => Boolean = f => f.isDirectory && !f.getName.startsWith(".")
+  val DefaultListingPolicy = (f:File) => isNotebookFile(f) || isVisibleDirectory(f)
 }
 

--- a/src/test/scala/notebook/NBSerializerTests.scala
+++ b/src/test/scala/notebook/NBSerializerTests.scala
@@ -66,6 +66,8 @@ class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll wi
       |}
     """.stripMargin
 
+  val emptyNotebookSer ="{}"
+
   val notebookWithContent = Notebook(Some(metadata), nbformat = None, rawContent = Some(notebookSer))
   val notebookWithoutContent = Notebook(Some(metadata), nbformat = None, rawContent = None)
 
@@ -84,5 +86,13 @@ class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll wi
         ser should be (notebookWithContent)
       }
     }
+
+    "fail to deserialize an empty Json" in {
+      val fdser = Notebook.read(emptyNotebookSer)
+      whenReady (fdser.failed) { ex =>
+        ex shouldBe a [EmptyNotebookException]
+      }
+    }
+
   }
 }

--- a/src/test/scala/notebook/NotebookSerializationTests.scala
+++ b/src/test/scala/notebook/NotebookSerializationTests.scala
@@ -96,7 +96,7 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
     "fail to deserialize invalid Json" in {
       val fdser = Notebook.read("{:=")
       whenReady (fdser.failed) { ex =>
-        ex shouldBe a [EmptyNotebookException]
+        ex shouldBe a [NotebookDeserializationException]
       }
     }
 

--- a/src/test/scala/notebook/NotebookSerializationTests.scala
+++ b/src/test/scala/notebook/NotebookSerializationTests.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.{JsNumber, JsObject}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
+class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   implicit val defaultPatience =
     PatienceConfig(timeout =  Span(2, Seconds), interval = Span(5, Millis))
@@ -66,7 +66,6 @@ class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll wi
       |}
     """.stripMargin
 
-  val emptyNotebookSer ="{}"
 
   val notebookWithContent = Notebook(Some(metadata), nbformat = None, rawContent = Some(notebookSer))
   val notebookWithoutContent = Notebook(Some(metadata), nbformat = None, rawContent = None)
@@ -88,7 +87,14 @@ class NBSerializerTests extends WordSpec with Matchers with BeforeAndAfterAll wi
     }
 
     "fail to deserialize an empty Json" in {
-      val fdser = Notebook.read(emptyNotebookSer)
+      val fdser = Notebook.read("{}")
+      whenReady (fdser.failed) { ex =>
+        ex shouldBe a [EmptyNotebookException]
+      }
+    }
+
+    "fail to deserialize invalid Json" in {
+      val fdser = Notebook.read("{:=")
       whenReady (fdser.failed) { ex =>
         ex shouldBe a [EmptyNotebookException]
       }

--- a/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
+++ b/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
@@ -3,8 +3,6 @@ package notebook.io
 import java.nio.file.{Files, Path}
 
 import com.typesafe.config.ConfigFactory
-import notebook.NBSerializer.{Metadata, Notebook}
-import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import play.api.libs.json.{JsNumber, JsObject}

--- a/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
+++ b/src/test/scala/notebook/io/FileSystemNotebookProviderConfiguratorTests.scala
@@ -29,8 +29,7 @@ class FileSystemNotebookProviderConfiguratorTests extends WordSpec with Matchers
     "configure a new notebook provider" in {
       val configurator = Class.forName("notebook.io.FileSystemNotebookProviderConfigurator").newInstance().asInstanceOf[Configurable[NotebookProvider]]
       val dirConfig = ConfigFactory.parseMap(Map("notebook.dir" -> notebookDir).asJava)
-      val provider = new FileSystemNotebookProviderConfigurator()
-      val notebookProvider = provider(dirConfig )
+      val notebookProvider = configurator(dirConfig )
       notebookProvider shouldBe a[NotebookProvider]
     }
   }

--- a/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
+++ b/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
@@ -1,11 +1,15 @@
 package notebook.io
 
-import java.nio.file.{Files, Path}
+import java.nio.file.{Files, Path, Paths}
+import java.util.TimeZone
 
 import com.typesafe.config.ConfigFactory
-import notebook.NBSerializer.{Metadata, Notebook}
+import notebook.NBSerializer.Metadata
+import notebook.Notebook
 import org.apache.commons.io.FileUtils
+import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import play.api.libs.json.{JsNumber, JsObject}
 
@@ -29,22 +33,49 @@ class FileSystemNotebookProviderTests extends WordSpec with Matchers with Before
   val customArgs = Some(List.empty[String])
   val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
 
+  val metadata = new Metadata(
+    name = testName,
+    user_save_timestamp =  new DateTime(1999, 9, 9, 9, 9, 9,DateTimeZone.forID("CET")).toDate,
+    auto_save_timestamp =  new DateTime(2001, 1, 1, 0, 0, 0,DateTimeZone.forID("CET")).toDate,
+    sparkNotebook = Some(sparkNotebook),
+    customLocalRepo = customLocalRepo,
+    customRepos = customRepos,
+    customDeps = customDeps,
+    customImports = customImports,
+    customArgs = customArgs,
+    customSparkConf = customSparkConf)
+
+  val raw =
+    """{
+      |"metadata" : {
+      |  "name" : "test-notebook-name",
+      |  "user_save_timestamp" : "1999-09-09T09:09:09.000Z",
+      |  "auto_save_timestamp" : "2001-01-01T00:00:00.000Z",
+      |  "language_info" : {
+      |    "name" : "scala",
+      |    "file_extension" : "scala",
+      |    "codemirror_mode" : "text/x-scala"
+      |  },
+      |  "trusted" : true,
+      |  "sparkNotebook" : {
+      |    "build" : "unit-tests"
+      |  },
+      |  "customLocalRepo" : "local-repo",
+      |  "customRepos" : [ "custom-repo" ],
+      |  "customDeps" : [ "\"org.custom\" % \"dependency\" % \"1.0.0\"" ],
+      |  "customImports" : [ "import org.cusom.dependency.SomeClass" ],
+      |  "customArgs" : [ ],
+      |  "customSparkConf" : {
+      |    "spark.driverPort" : 1234
+      |  }
+      |},
+      |"cells" : [ ]
+      |}
+    """.stripMargin
+
   override def beforeAll: Unit = {
-    notebook = Notebook(
-      Some(new Metadata(
-        name = testName,
-        sparkNotebook = Some(sparkNotebook),
-        customLocalRepo = customLocalRepo,
-        customRepos = customRepos,
-        customDeps = customDeps,
-        customImports = customImports,
-        customArgs = customArgs,
-        customSparkConf = customSparkConf)),
-      Some(Nil),
-      None,
-      None,
-      None
-    )
+    notebook = Notebook(metadata = Some(metadata), nbformat = None, rawContent = Some(raw))
+
     temp = Files.createTempDirectory("file-system-notebook-provider")
     val notebookDir = temp.toAbsolutePath.toFile.getAbsolutePath + "/notebook"
     val dirConfig = ConfigFactory.parseMap(Map("notebook.dir" -> notebookDir).asJava)
@@ -61,28 +92,36 @@ class FileSystemNotebookProviderTests extends WordSpec with Matchers with Before
   "File system notebook provider" should {
 
     "create a notebook file" in {
-      whenReady( provider.save(target, notebook) ) { n =>
-        n shouldBe(Some(notebook))
+      whenReady( provider.save(target, notebook) ,  timeout(Span(1, Seconds))) { n =>
+        n should be (notebook)
       }
     }
 
     "load created file" in {
-      whenReady( provider.get(target) ) { n =>
-        n shouldBe(Some(notebook))
+      whenReady( provider.get(target), timeout(Span(1, Seconds)) ) { n =>
+        n should be (notebook)
+      }
+    }
+
+    "fail to load an unexisting file" in {
+      whenReady( provider.get(Paths.get("/path/to/nowhere")).failed ) { n =>
+        n shouldBe a [java.nio.file.NoSuchFileException]
       }
     }
 
     "delete the file" in {
       whenReady( provider.delete(target) ) { n =>
-        n shouldBe(Some(notebook))
+        n should be (notebook)
       }
     }
 
     "fail to load deleted file" in {
-      whenReady( provider.get(target) ) { n =>
-        n shouldBe(None)
+      whenReady( provider.get(target).failed ) { n =>
+        n shouldBe a [java.nio.file.NoSuchFileException]
       }
     }
+
+
 
   }
 

--- a/src/test/scala/notebook/io/NotebookProviderTests.scala
+++ b/src/test/scala/notebook/io/NotebookProviderTests.scala
@@ -2,19 +2,21 @@ package notebook.io
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
+import java.io.File
 
-import com.typesafe.config.ConfigFactory
-import notebook.NBSerializer.{GenericFile, Notebook, NotebookResource}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 import org.apache.commons.io.FileUtils
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
-
-import scala.concurrent.Future
-
+import notebook.{GenericFile, Notebook, NotebookResource}
+import org.scalatest.time.{Millis, Seconds, Span}
 
 class NotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAll with ScalaFutures {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
+  implicit val defaultPatience =
+    PatienceConfig(timeout =  Span(2, Seconds), interval = Span(5, Millis))
 
   val rootPath = Files.createTempDirectory("notebook-provider-test")
   val notebookPath = rootPath.resolve("notebook")
@@ -34,15 +36,38 @@ class NotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAl
     FileUtils.deleteDirectory(rootPath.toFile)
   }
 
+  class BaseProvider extends NotebookProvider {
+    override def root: Path = rootPath
+    override def get(path: Path) (implicit ev:ExecutionContext): Future[Notebook] = ???
+    override def delete(path: Path) (implicit ev:ExecutionContext): Future[Notebook] = ???
+    override def save(path: Path, notebook: Notebook) (implicit ev:ExecutionContext): Future[Notebook] = ???
+  }
+
+  val T = true
+  val F = false
+
+  val providerDefault = new BaseProvider()
+
+  val providerNoFilter = new BaseProvider(){
+    override val listingPolicy = (f:File) => true
+  }
+
+  val providerExplicitFilter = new BaseProvider() {
+    override val listingPolicy = (f:File) => (f.getName endsWith ".snb") || (f.getName startsWith "res")
+  }
+
+  val providerPatternFilter = new BaseProvider() {
+    override val listingPolicy = (f:File) =>
+      if (f.isDirectory) {
+        !f.getName.startsWith(".")
+      } else {
+        f.getName.endsWith(".snb")
+    }
+  }
+
   "Notebook provider" should {
 
-    val defaultInstance = new NotebookProvider() {
-      override def root: Path = rootPath
-      val successfulNothing : Future[Option[Notebook]] = Future.successful(None)
-      override def get(path: Path)(implicit ev: scala.concurrent.ExecutionContext): Future[Option[Notebook]] = successfulNothing
-      override def delete(path: Path)(implicit ev: scala.concurrent.ExecutionContext): Future[Option[Notebook]] = successfulNothing
-      override def save(path: Path, notebook: Notebook)(implicit ev: scala.concurrent.ExecutionContext): Future[Option[Notebook]] = successfulNothing
-    }
+    val defaultInstance = new BaseProvider()
 
     "retrieve a list of resources from a path" in {
       whenReady(defaultInstance.list(notebookPath) ) { files =>


### PR DESCRIPTION
This PR iams to push down some of the complexity of project generation by making a 'fatter' notebook object that can hold some of the data that we need to pass in parallel code paths.

It also introduces a number of application-level exceptions and uses them to report issues in operations.

Adds test coverage.

@andypetrella @radekg for review