### PR TITLE
Add output information to cell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "guru.data-fellas"
 
 name := "spark-notebook-core"
 
-version := "0.1.3-SNAPSHOT"
+version := "0.2.0-SNAPSHOT"
 
 bintrayRepository := "spark-notebook"
 

--- a/src/main/scala/notebook/NBSerializer.scala
+++ b/src/main/scala/notebook/NBSerializer.scala
@@ -140,8 +140,8 @@ object NBSerializer {
 
   case class Metadata(
                        name: String,
-                       user_save_timestamp: Date ,
-                       auto_save_timestamp: Date ,
+                       user_save_timestamp: Date,
+                       auto_save_timestamp: Date,
                        language_info: LanguageInfo = scala,
                        trusted: Boolean = true,
                        sparkNotebook:Option[Map[String, String]] = None,

--- a/src/main/scala/notebook/NBSerializer.scala
+++ b/src/main/scala/notebook/NBSerializer.scala
@@ -103,6 +103,7 @@ object NBSerializer {
                        source: String,
                        language: Option[String],
                        prompt_number: Option[Int] = None,
+                       output: Option[JsObject] = None,
                        outputs: Option[List[Output]] = None
                      ) extends Cell
 


### PR DESCRIPTION
This will allow to serialize the information in the cell (json)

This will help to have output cells that won't be based on code content with `:output` text in them

cc @maasg 