### PR TITLE
remove trailing dashes of cleaned notebook name

### DIFF
--- a/src/main/scala/notebook/Notebook.scala
+++ b/src/main/scala/notebook/Notebook.scala
@@ -11,7 +11,10 @@ trait Notebook {
   def autosaved: Option[List[Worksheet]] = None
   def nbformat: Option[Int]
   def name: String = metadata.map(_.name).getOrElse("Anonymous")
-  def normalizedName: String = name.toLowerCase.replaceAll("[^\\.a-z_-]", "-")
+  def normalizedName: String = {
+    val n = name.toLowerCase.replaceAll("[^\\.a-z_-]", "-")
+    n.dropWhile(_ == '-').reverse.dropWhile(_ == '-').reverse
+  }
   def rawContent: Option[String] = None
   def isFromRaw = rawContent.isDefined
 }


### PR DESCRIPTION
quick fix to clean leading and trailing dashes

we'll might have to change it again to accept numbers (but the leading ones)