### PR TITLE
Introduces a 'customEnv' stanza in the metadata

### DIFF
--- a/src/main/scala/notebook/NBSerializer.scala
+++ b/src/main/scala/notebook/NBSerializer.scala
@@ -171,7 +171,6 @@ object NBSerializer {
         (JsPath \ "customSparkConf").readNullable[JsObject] and
         (JsPath \ "customVars").readNullable[Map[String,String]]
       )(Metadata.apply _)
-//(JsPath \ "customEnv").readNullable[Map[String, String]]
 
     val w: Writes[Metadata] =
       OWrites { (m: Metadata) =>

--- a/src/main/scala/notebook/NBSerializer.scala
+++ b/src/main/scala/notebook/NBSerializer.scala
@@ -151,7 +151,7 @@ object NBSerializer {
                        customImports: Option[List[String]] = None,
                        customArgs: Option[List[String]] = None,
                        customSparkConf: Option[JsObject] = None,
-                       customEnv: Option[Map[String, String]] = None
+                       customVars: Option[Map[String, String]] = None
                      )
 
   implicit val metadataFormat: Format[Metadata] = {
@@ -169,7 +169,7 @@ object NBSerializer {
         (JsPath \ "customImports").readNullable[List[String]] and
         (JsPath \ "customArgs").readNullable[List[String]] and
         (JsPath \ "customSparkConf").readNullable[JsObject] and
-        (JsPath \ "customEnv").readNullable[Map[String,String]]
+        (JsPath \ "customVars").readNullable[Map[String,String]]
       )(Metadata.apply _)
 //(JsPath \ "customEnv").readNullable[Map[String, String]]
 
@@ -193,7 +193,7 @@ object NBSerializer {
           "customImports" → m.customImports,
           "customArgs" → m.customArgs,
           "customSparkConf" → m.customSparkConf,
-          "customEnv" -> m.customEnv
+          "customVars" -> m.customVars
         )
       }
 

--- a/src/main/scala/notebook/NBSerializer.scala
+++ b/src/main/scala/notebook/NBSerializer.scala
@@ -150,7 +150,8 @@ object NBSerializer {
                        customDeps: Option[List[String]] = None,
                        customImports: Option[List[String]] = None,
                        customArgs: Option[List[String]] = None,
-                       customSparkConf: Option[JsObject] = None
+                       customSparkConf: Option[JsObject] = None,
+                       customEnv: Option[Map[String, String]] = None
                      )
 
   implicit val metadataFormat: Format[Metadata] = {
@@ -167,8 +168,10 @@ object NBSerializer {
         (JsPath \ "customDeps").readNullable[List[String]] and
         (JsPath \ "customImports").readNullable[List[String]] and
         (JsPath \ "customArgs").readNullable[List[String]] and
-        (JsPath \ "customSparkConf").readNullable[JsObject]
+        (JsPath \ "customSparkConf").readNullable[JsObject] and
+        (JsPath \ "customEnv").readNullable[Map[String,String]]
       )(Metadata.apply _)
+//(JsPath \ "customEnv").readNullable[Map[String, String]]
 
     val w: Writes[Metadata] =
       OWrites { (m: Metadata) =>
@@ -189,7 +192,8 @@ object NBSerializer {
           "customDeps" → m.customDeps,
           "customImports" → m.customImports,
           "customArgs" → m.customArgs,
-          "customSparkConf" → m.customSparkConf
+          "customSparkConf" → m.customSparkConf,
+          "customEnv" -> m.customEnv
         )
       }
 

--- a/src/test/scala/notebook/NotebookSerializationTests.scala
+++ b/src/test/scala/notebook/NotebookSerializationTests.scala
@@ -25,7 +25,7 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
   val customImports = Some(List("""import org.cusom.dependency.SomeClass"""))
   val customArgs = Some(List.empty[String])
   val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
-  val customEnv = Some(Map( "HDFS_ROOT" -> "/tmp", "INTERNAL_DOCS" ->  "confidential"))
+  val customVars = Some(Map( "HDFS_ROOT" -> "/tmp", "INTERNAL_DOCS" ->  "confidential"))
 
   val metadata = new Metadata(
     name = testName,
@@ -38,7 +38,7 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
     customImports = customImports,
     customArgs = customArgs,
     customSparkConf = customSparkConf,
-    customEnv = customEnv
+    customVars = customVars
   )
 
   val notebookSer =
@@ -64,7 +64,7 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
       |    "customSparkConf" : {
       |      "spark.driverPort" : 1234
       |    },
-      |    "customEnv" : {
+      |    "customVars" : {
       |      "HDFS_ROOT" : "/tmp",
       |      "INTERNAL_DOCS" : "confidential"
       |    }

--- a/src/test/scala/notebook/NotebookSerializationTests.scala
+++ b/src/test/scala/notebook/NotebookSerializationTests.scala
@@ -25,6 +25,7 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
   val customImports = Some(List("""import org.cusom.dependency.SomeClass"""))
   val customArgs = Some(List.empty[String])
   val customSparkConf = Some(JsObject( List(("spark.driverPort", JsNumber(1234))) ))
+  val customEnv = Some(Map( "HDFS_ROOT" -> "/tmp", "INTERNAL_DOCS" ->  "confidential"))
 
   val metadata = new Metadata(
     name = testName,
@@ -36,7 +37,9 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
     customDeps = customDeps,
     customImports = customImports,
     customArgs = customArgs,
-    customSparkConf = customSparkConf)
+    customSparkConf = customSparkConf,
+    customEnv = customEnv
+  )
 
   val notebookSer =
     """{
@@ -60,6 +63,10 @@ class NotebookSerializationTests extends WordSpec with Matchers with BeforeAndAf
       |    "customArgs" : [ ],
       |    "customSparkConf" : {
       |      "spark.driverPort" : 1234
+      |    },
+      |    "customEnv" : {
+      |      "HDFS_ROOT" : "/tmp",
+      |      "INTERNAL_DOCS" : "confidential"
       |    }
       |  },
       |  "cells" : [ ]


### PR DESCRIPTION
adds a new configuration stanza "customEnv" that will hold the custom environment configuration for the notebook.

@frbayart @andypetrella This is the start of "customEnv" support (PR 1/3)
