### PR TITLE
Fix/adyx 26 support notebook move

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "guru.data-fellas"
 
 name := "spark-notebook-core"
 
-version := "0.3.1-SNAPSHOT"
+version := "0.3.2-SNAPSHOT"
 
 publishArtifact in Test := false
 

--- a/src/main/scala/notebook/Notebook.scala
+++ b/src/main/scala/notebook/Notebook.scala
@@ -17,6 +17,7 @@ trait Notebook {
   }
   def rawContent: Option[String] = None
   def isFromRaw = rawContent.isDefined
+  def updateMetadata(newMeta: Option[Metadata]): Notebook
 }
 
 
@@ -28,7 +29,9 @@ object Notebook {
                            override val autosaved: Option[List[Worksheet]] = None,
                            override val nbformat: Option[Int],
                            override val rawContent: Option[String]
-                         ) extends Notebook
+                         ) extends Notebook {
+    override def updateMetadata(newMeta: Option[Metadata]): Notebook = this.copy(metadata = newMeta)
+  }
 
   def apply(metadata: Option[Metadata] = None,
             cells: Option[List[Cell]] = Some(Nil),

--- a/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
+++ b/src/main/scala/notebook/io/FileSystemNotebookProviderConfigurator.scala
@@ -49,6 +49,16 @@ class FileSystemNotebookProviderConfigurator extends Configurable[NotebookProvid
           Files.write(path, nb.getBytes(StandardCharsets.UTF_8))
       }.map(_ => notebook)
     }
+
+    // Moves the notebook at src Path to the dest Path
+    override def moveInternal(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = Future {
+      require(src.toFile.exists(), s"Notebook source at [$src] should exist")
+      require(dest.getParent.toFile.exists(), s"Directory at [${dest.getParent()}] should exist")
+      require(!dest.toFile.exists(), s"Notebook dest at [$dest] should not exist")
+      Files.move(src, dest)
+      dest
+    }
+
   }
 }
 object FileSystemNotebookProviderConfigurator {

--- a/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/src/main/scala/notebook/io/NotebookProvider.scala
@@ -6,6 +6,7 @@ import java.nio.file.{DirectoryNotEmptyException, Files, Path, Paths}
 import java.io.{File, FileFilter, IOException}
 
 import com.typesafe.config.{Config, ConfigFactory}
+import notebook.NBSerializer.Metadata
 import notebook._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,11 +29,34 @@ trait NotebookProvider {
 
   def save(path: Path, notebook: Notebook, saveSpec: Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook]
 
-  // Moves the notebook at src Path to the dest Path
-  def move(src:Path, dest: Path)(implicit ev: ExecutionContext): Future[Path]
+  // Moves the notebook with name notebookName at src Path to the dest Path
+  final def move(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = {
+    val srcName = src.getFileName.toString
+    val destName = dest.getFileName.toString
+    for {
+      moved <- moveInternal(src, dest)
+      res <- if (srcName == destName) {
+          Future.successful(dest)
+        } else {
+        renameInternal(moved, destName)
+      }
+    } yield res
+  }
 
-  // Renames a notebook
-  def rename(src: Path, newName: String, nb: Notebook)(implicit ev: ExecutionContext): Future[Path]
+  // physically moves the notebook, following the logic inherent to the provider
+  def moveInternal(src:Path, dest: Path)(implicit ev: ExecutionContext): Future[Path]
+
+  // Renames the internal data of a notebook
+  final def renameInternal(path: Path, newName: String)(implicit ev: ExecutionContext): Future[Path] = {
+    val now = new java.util.Date()
+    for {
+      nb <- get(path)
+      meta = nb.metadata.map(_.copy(id=java.util.UUID.randomUUID.toString, name = newName, user_save_timestamp = now))
+        .orElse(Some(new Metadata(java.util.UUID.randomUUID.toString, newName, now, now)))
+      renamedNb = Notebook(meta, nb.cells, nb.worksheets, nb.autosaved, nb.nbformat, nb.rawContent)
+      _ <- save(path, renamedNb)
+    } yield (path)
+  }
 
   // retrieves available versions of the provided notebook path. To be extended by providers that support versioning.
   def versions(path:Path)(implicit ev: ExecutionContext): Future[List[Version]] = Future.successful(Nil)

--- a/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/src/main/scala/notebook/io/NotebookProvider.scala
@@ -53,7 +53,7 @@ trait NotebookProvider {
       nb <- get(path)
       meta = nb.metadata.map(_.copy(id=java.util.UUID.randomUUID.toString, name = newName, user_save_timestamp = now))
         .orElse(Some(new Metadata(java.util.UUID.randomUUID.toString, newName, now, now)))
-      renamedNb = Notebook(meta, nb.cells, nb.worksheets, nb.autosaved, nb.nbformat, nb.rawContent)
+      renamedNb = nb.updateMetadata(meta)
       _ <- save(path, renamedNb)
     } yield (path)
   }

--- a/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/src/main/scala/notebook/io/NotebookProvider.scala
@@ -51,7 +51,7 @@ trait NotebookProvider {
     val now = new java.util.Date()
     for {
       nb <- get(path)
-      meta = nb.metadata.map(_.copy(id=java.util.UUID.randomUUID.toString, name = newName, user_save_timestamp = now))
+      meta = nb.metadata.map(_.copy(name = newName, user_save_timestamp = now))
         .orElse(Some(new Metadata(java.util.UUID.randomUUID.toString, newName, now, now)))
       renamedNb = nb.updateMetadata(meta)
       _ <- save(path, renamedNb)

--- a/src/main/scala/notebook/io/NotebookProvider.scala
+++ b/src/main/scala/notebook/io/NotebookProvider.scala
@@ -28,6 +28,12 @@ trait NotebookProvider {
 
   def save(path: Path, notebook: Notebook, saveSpec: Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook]
 
+  // Moves the notebook at src Path to the dest Path
+  def move(src:Path, dest: Path)(implicit ev: ExecutionContext): Future[Path]
+
+  // Renames a notebook
+  def rename(src: Path, newName: String, nb: Notebook)(implicit ev: ExecutionContext): Future[Path]
+
   // retrieves available versions of the provided notebook path. To be extended by providers that support versioning.
   def versions(path:Path)(implicit ev: ExecutionContext): Future[List[Version]] = Future.successful(Nil)
 

--- a/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
+++ b/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
@@ -176,6 +176,20 @@ class FileSystemNotebookProviderTests extends WordSpec with Matchers with Before
       }
     }
 
+    "preserve the id of a renamed notebook" in {
+      val nbPath = notebookPath.resolve("testinternal-rename.snb")
+      val originalId = notebook.metadata.get.id
+      val res = for {
+        nb <- provider.save(nbPath, notebook)
+        _ <- provider.renameInternal(nbPath, "testinternal-renamed")
+        renamed <- provider.get(nbPath)
+      } yield renamed
+
+      whenReady(res) { renamedNb =>
+        renamedNb.metadata.get.id should be(originalId)
+      }
+    }
+
     "fail to move an unexisting notebook" in {
       whenReady( provider.move(Paths.get("/path/to/nowhere"), notebookPath).failed ) { n =>
         n shouldBe a [java.lang.IllegalArgumentException]

--- a/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
+++ b/src/test/scala/notebook/io/FileSystemNotebookProviderTests.scala
@@ -86,7 +86,11 @@ class FileSystemNotebookProviderTests extends WordSpec with Matchers with Before
       |}
     """.stripMargin
 
-  val notebook = Notebook(metadata = Some(metadata), nbformat = None, rawContent = Some(raw))
+  val notebook = {
+    val nb = Notebook(metadata = Some(metadata), nbformat = None, rawContent = Some(raw))
+    val normalizedNb = Notebook.write(nb).flatMap(Notebook.read(_))
+    Await.result(normalizedNb, DefaultWaitSeconds)
+  }
 
   override def beforeAll: Unit = {
     tempPath = Files.createTempDirectory("file-system-notebook-provider")
@@ -128,14 +132,66 @@ class FileSystemNotebookProviderTests extends WordSpec with Matchers with Before
       } yield loaded
 
       whenReady( loadedNb ) { nb =>
-        nb.normalizedName should be (notebook.normalizedName)
-        nb.metadata should be (notebook.metadata)
-        nb.cells should be (notebook.cells)
-        nb.name should be (notebook.name)
-        nb.autosaved should be (notebook.autosaved)
-        nb.nbformat should be (notebook.nbformat)
-        nb.worksheets should be (notebook.worksheets)
-        // avoid comparing the raw content b/c it differs in indentation after JSON pretty print
+        nb should be (notebook)
+      }
+    }
+
+    "move a notebook file to another directory" in {
+      val nbName = "testMove.snb"
+      val originalPath = notebookPath.resolve(nbName)
+      val targetDir = notebookPath.resolve(s"dest")
+      Files.createDirectories(targetDir)
+      val targetNbPath = targetDir.resolve(nbName)
+
+      val moved = for {
+        _ <- provider.save(originalPath, notebook)
+        path <- provider.move(originalPath, targetNbPath)
+        nb <- provider.get(path)
+      } yield (nb, path)
+
+      whenReady(moved) { case (nb, path) =>
+        path should be (targetNbPath)
+        originalPath.toFile.exists() should be(false)
+        path.toFile.exists() should be(true)
+        nb should be (notebook)
+      }
+    }
+
+    "rename a notebook file" in {
+      val originalPath = notebookPath.resolve("testRename.snb")
+      val newName = "renamed.snb"
+      val destPath = notebookPath.resolve(newName)
+
+      val renamedNotebook = for {
+        _ <- provider.save(originalPath, notebook)
+        newPath <- provider.move(originalPath, destPath)
+        renamedNb <- provider.get(newPath)
+      } yield renamedNb
+
+      whenReady (renamedNotebook) {nb =>
+        originalPath.toFile.exists() should be (false)
+        destPath.toFile.exists() should be (true)
+        nb.name should be (newName)
+        nb.metadata.get.name should be (newName)
+      }
+    }
+
+    "fail to move an unexisting notebook" in {
+      whenReady( provider.move(Paths.get("/path/to/nowhere"), notebookPath).failed ) { n =>
+        n shouldBe a [java.lang.IllegalArgumentException]
+      }
+    }
+
+    "fail to move a notebook to a non-existing directory" in {
+      val nbPath = notebookPath.resolve("testMoveNonExist.snb")
+      val nonExistingPath = notebookPath.resolve("nowhere/testMoveNonExist.snb")
+      val test = for {
+        nb <- provider.save(nbPath, notebook)
+        moved <- provider.move(nbPath, nonExistingPath)
+      }  yield (moved)
+
+      whenReady( test.failed ) { failure =>
+        failure shouldBe a[java.lang.IllegalArgumentException]
       }
     }
 

--- a/src/test/scala/notebook/io/NotebookProviderTests.scala
+++ b/src/test/scala/notebook/io/NotebookProviderTests.scala
@@ -53,6 +53,7 @@ class NotebookProviderTests extends WordSpec with Matchers with BeforeAndAfterAl
     override def get(path: Path, version: Option[Version])(implicit ev: ExecutionContext): Future[Notebook] = ???
     override def delete(path: Path)(implicit ev: ExecutionContext): Future[Notebook] = ???
     override def save(path: Path, notebook: Notebook, saveSpec:Option[String] = None)(implicit ev: ExecutionContext): Future[Notebook] = ???
+    override def moveInternal(src: Path, dest: Path)(implicit ev: ExecutionContext): Future[Path] = ???
   }
 
   val T = true


### PR DESCRIPTION
Adds `move` operation to the abstract provider and implements rename at the trait level, using abstract methods.

@frbayart @andypetrella PR (1/3) solves ADYX-26 affecting AXA